### PR TITLE
failed building with cloudflare pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,5 @@ end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :install_if => Gem.win_platform?
+
+gem "jekyll-sass-converter", "~> 2.0"


### PR DESCRIPTION
Hi

I faced an error and the solution was: [source](https://community.cloudflare.com/t/deployment-failing-rubygems-version/446483)

full log:

```shell
2022-12-28T15:08:32.137012Z	Cloning repository...
2022-12-28T15:08:33.276262Z	From https://github.com/alerezaaa/Jekyll_CF-Mine
2022-12-28T15:08:33.276857Z	 * branch            9efaf9270b9d51b72f7477555f68f4b2c6a369b9 -> FETCH_HEAD
2022-12-28T15:08:33.27702Z	
2022-12-28T15:08:33.335699Z	HEAD is now at 9efaf92 Update Gemfile
2022-12-28T15:08:33.336236Z	
2022-12-28T15:08:35.135238Z	Submodule 'assets/lib' (https://github.com/cotes2020/chirpy-static-assets.git) registered for path 'assets/lib'
2022-12-28T15:08:35.135899Z	Cloning into '/opt/buildhome/clone/assets/lib'...
2022-12-28T15:08:35.136102Z	Submodule path 'assets/lib': checked out 'd1d2ec17c88176753d4dd2a1296620021dcc22fd'
2022-12-28T15:08:35.136233Z	
2022-12-28T15:08:35.164845Z	Success: Finished cloning repository files
2022-12-28T15:08:35.8632Z	Installing dependencies
2022-12-28T15:08:35.874989Z	Python version set to 2.7
2022-12-28T15:08:39.357012Z	v12.18.0 is already installed.
2022-12-28T15:08:40.58818Z	Now using node v12.18.0 (npm v6.14.4)
2022-12-28T15:08:40.824309Z	Started restoring cached build plugins
2022-12-28T15:08:40.83967Z	Finished restoring cached build plugins
2022-12-28T15:08:41.331706Z	Attempting ruby version 2.7.1, read from environment
2022-12-28T15:08:44.933195Z	Using ruby version 2.7.1
2022-12-28T15:08:45.293835Z	Using PHP version 5.6
2022-12-28T15:08:45.294597Z	Started restoring cached ruby gems
2022-12-28T15:08:45.309498Z	Finished restoring cached ruby gems
2022-12-28T15:08:45.310354Z	Installing gem bundle
2022-12-28T15:08:45.590343Z	[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path '/opt/buildhome/cache/bundle'`, and stop using this flag
2022-12-28T15:08:45.740204Z	[DEPRECATED] The --binstubs option will be removed in favor of `bundle binstubs`
2022-12-28T15:08:48.28386Z	Fetching gem metadata from https://rubygems.org/...........
2022-12-28T15:08:48.491803Z	Fetching gem metadata from https://rubygems.org/.
2022-12-28T15:08:48.597918Z	Resolving dependencies...
2022-12-28T15:08:48.639482Z	sass-embedded-1.57.1-x86_64-linux-gnu requires rubygems version >= 3.3.22, which
2022-12-28T15:08:48.639816Z	is incompatible with the current version, 3.1.2
2022-12-28T15:08:48.684224Z	Error during gem install
2022-12-28T15:08:48.687796Z	Failed: build command exited with code: 1
2022-12-28T15:08:49.481707Z	Failed: an internal error occurred
```