### PR TITLE
fix: added dependency installation to `pages-deploy.yml`

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -45,6 +45,9 @@ jobs:
           ruby-version: 3
           bundler-cache: true
 
+      - name: Install dependencies
+        run: bundle install
+
       - name: Build site
         run: bundle exec jekyll b -d "_site${{ steps.pages.outputs.base_path }}"
         env:


### PR DESCRIPTION
CI currently does not install the Jekyll theme Gem. This causes the following error when trying to run the CI for GitHub Pages.

```
Error:  The jekyll-theme-chirpy theme could not be found.
```

This PR adds this to the workflow.