### PR TITLE
#: update ruby-version

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3
+          ruby-version: 3.2
           bundler-cache: true
 
       - name: Build site


### PR DESCRIPTION
"Setup Ruby" job  failed with ruby-version 3
my log
An error occurred while installing google-protobuf (3.25.1), and Bundler cannot
continue.
...
Error: The process '/opt/hostedtoolcache/Ruby/3.3.0/x64/bin/bundle' failed with exit code 5