### PR TITLE
fix: google analytics key fix

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,8 +49,9 @@ google_site_verification: # fill in to your verification string
 # ↑ --------------------------
 # The end of `jekyll-seo-tag` settings
 
-google_analytics:
-  id: # fill in your Google Analytics ID
+analytics:
+  google:
+    id: : # fill in your Google Analytics ID
 
 goatcounter:
   id: # fill in your Goatcounter ID


### PR DESCRIPTION
Google Analytics tag key isn't setup properly in the _config.yml. In _includes/analytics/google.html, the following key is used: {{ site.analytics.google.id }} which is currently unavailable.