### PR TITLE
Add explicit future setting to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,9 @@ description: >- # used by seo meta and the atom feed
 # E.g. 'https://username.github.io', note that it does not end with a '/'.
 url: ""
 
+# Whether to publish posts with a future date
+future: false
+
 github:
   username: github_username # change to your GitHub username
 


### PR DESCRIPTION
I spent a considerable time debugging why some of my posts aren't showing on the blog when testing an article locally only to realize it's due to them being set to a future date which Jekyll doesn't show by default. This can be overridden by setting `future: true` in `_config.yml`.

I propose adding the default `future: false` to make this explicit and thus easier to find.