### PR TITLE
Update comments and links for time zone configuration in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,8 @@ theme: jekyll-theme-chirpy
 # otherwise, the layout language will use the default value of 'en'.
 lang: en
 
-# Change to your timezone › https://kevinnovak.github.io/Time-Zone-Picker
+# Change to your timezone › https://kevalbhatt.github.io/timezone-picker/
+# e.g. 'Asia/Shanghai', 'America/New_York', etc.
 timezone:
 
 # jekyll-seo-tag settings › https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/usage.md


### PR DESCRIPTION
Update the comments for the time zone configuration, add examples, and correct the link to the time zone selector
The original link https://kevinnovak.github.io/Time-Zone-Picker Unable to access, has been modified to the latest link: https://kevalbhatt.github.io/timezone-picker/