### PR TITLE
fix: update platforms in Gemfile for Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ gem "jekyll-theme-chirpy", "~> 7.4", ">= 7.4.1"
 
 gem "html-proofer", "~> 5.0", group: :test
 
-platforms :mingw, :x64_mingw, :mswin, :jruby do
+platforms :windows, :jruby do
   gem "tzinfo", ">= 1", "< 3"
   gem "tzinfo-data"
 end
 
-gem "wdm", "~> 0.2.0", :platforms => [:mingw, :x64_mingw, :mswin]
+gem "wdm", "~> 0.2.0", :platforms => [:windows]


### PR DESCRIPTION
`Gemfile` specifies plaforms `:mingw, :x64_mingw, :mswin`

When I run `bundle install`, I get the warning: 

```
[DEPRECATED] Platform :mingw, :x64_mingw, :mswin is deprecated. Please use platform :windows instead.
```

This PR updates the deprecated platforms to `:windows`.